### PR TITLE
Update deploy.sh to use git rev-parse --short

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -5,7 +5,7 @@ curl -LSso Dockerrun.aws.json.template https://raw.githubusercontent.com/imperfe
 
 # Set vars that typically do not vary by app
 BRANCH=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)
-SHA1=$(git rev-parse HEAD)
+SHA1=$(git rev-parse --short HEAD)
 VERSION=$BRANCH-$SHA1-$(date +%s)
 DESCRIPTION=$(git log -1 --pretty=%B)
 DESCRIPTION=${DESCRIPTION:0:180} # truncate to 180 chars - max beanstalk version description is 200


### PR DESCRIPTION
Make the new AWS ELB table a little less terrible

This would be a reasonable change either way

Will need to update gist link:
https://github.com/imperfectproduce/website/blob/master/deploy.sh